### PR TITLE
Fix gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gem 'aws-sdk', '~> 2'
+gemspec
 
 group :development do
   gem "aruba"

--- a/hiera-eyaml-kms.gemspec
+++ b/hiera-eyaml-kms.gemspec
@@ -1,11 +1,8 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'hiera/backend/eyaml/encryptors/kms'
 
 Gem::Specification.new do |gem|
   gem.name          = "hiera-eyaml-kms"
-  gem.version       = Hiera::Backend::Eyaml::Encryptors::Kms::VERSION
+  gem.version       = "0.2"
   gem.description   = "AWS KMS encryptor for use with hiera-eyaml"
   gem.summary       = "Encryption plugin for hiera-eyaml backend for Hiera"
   gem.author        = "Allan Denot"
@@ -16,4 +13,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_runtime_dependency 'aws-sdk-kms'
 end

--- a/lib/hiera/backend/eyaml/encryptors/kms.rb
+++ b/lib/hiera/backend/eyaml/encryptors/kms.rb
@@ -2,7 +2,7 @@ require 'openssl'
 require 'hiera/backend/eyaml/encryptor'
 require 'hiera/backend/eyaml/utils'
 require 'hiera/backend/eyaml/options'
-require 'aws-sdk'
+require 'aws-sdk-kms'
 
 class Hiera
   module Backend
@@ -26,18 +26,15 @@ class Hiera
           VERSION = "0.2"
           self.tag = "KMS"
 
-         
-
           def self.encrypt plaintext
             aws_profile = self.option :aws_profile
-            credentials = Aws::SharedCredentials.new(profile_name: aws_profile)
             aws_region = self.option :aws_region
             key_id = self.option :key_id
             raise StandardError, "key_id is not defined" unless key_id
 
             @kms = ::Aws::KMS::Client.new(
+              profile: aws_profile,
               region: aws_region,
-              credentials: credentials,
             )
 
             resp = @kms.encrypt({
@@ -50,12 +47,11 @@ class Hiera
 
           def self.decrypt ciphertext
             aws_profile = self.option :aws_profile
-            credentials = Aws::SharedCredentials.new(profile_name: aws_profile)
             aws_region = self.option :aws_region
 
             @kms = ::Aws::KMS::Client.new(
+              profile: aws_profile,
               region: aws_region,
-              credentials: credentials,
             )
 
             resp = @kms.decrypt({


### PR DESCRIPTION
Currently this gem fails to load because the `aws-sdk` is not declared as a dependency:

```
[!] There was an error while loading `hiera-eyaml-kms.gemspec`: cannot load such file -- aws-sdk
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from /etc/puppet/vendor/bundle/ruby/2.3.0/bundler/gems/hiera-eyaml-kms-f223553dbd50/hiera-eyaml-kms.gemspec:4
 #  -------------------------------------------
 #  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 >  require 'hiera/backend/eyaml/encryptors/kms'
 #
 #  -------------------------------------------
```

This diff fixes this issue and also bumps the AWS SDK to version 3.