### PR TITLE
Using EC2 Instance Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,12 @@ kms_aws_region: 'us-west-1'
 kms_aws_profile: 'your-profile'
 ```
 
+EC2 Instance Profile:
+
+The aws-sdk will use an EC2 Instance Profile if one is present and an AWS profile is not specified.
+
+
 Authors
 =======
 
 - [Allan Denot](http://github.com/adenot)
-


### PR DESCRIPTION
I'm suggesting a note be added to the README with respect to leveraging an EC2 Instance Profile if an AWS profile is not specified for credentials.