### PR TITLE
Remove need for setting aws config directly and rely on SDK methods/fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This plugin adds 2 options to hiera-eyaml:
 
 ```
 --kms-key-id=<s>            KMS Key ID  (default: )
---kms-aws-region=<s>        AWS Region  (default: ap-southeast-2)
---kms-aws-profile=<s>       AWS Profile (default: default)
 ```
 
 To avoid passing CLI parameters every call to eyaml, you can create a config file to set the defaults.
@@ -55,8 +53,6 @@ Example:
 ```yaml
 ---
 kms_key_id: '00000000-0000-0000-0000-000000000000'
-kms_aws_region: 'us-west-1'
-kms_aws_profile: 'your-profile'
 ```
 
 EC2 Instance Profile:

--- a/lib/hiera/backend/eyaml/encryptors/kms.rb
+++ b/lib/hiera/backend/eyaml/encryptors/kms.rb
@@ -10,32 +10,20 @@ class Hiera
       module Encryptors
 
         class Kms < Encryptor
-
           self.options = {
             :key_id => {      :desc => "KMS Key ID",
                               :type => :string,
                               :default => "" },
-            :aws_region => {  :desc => "AWS Region",
-                              :type => :string,
-                              :default => "ap-southeast-2" },
-            :aws_profile => { :desc => "AWS Account",
-                              :type => :string,
-                              :default => "default"}
           }
 
-          VERSION = "0.2"
+          VERSION = "0.3"
           self.tag = "KMS"
 
           def self.encrypt plaintext
-            aws_profile = self.option :aws_profile
-            aws_region = self.option :aws_region
             key_id = self.option :key_id
             raise StandardError, "key_id is not defined" unless key_id
 
-            @kms = ::Aws::KMS::Client.new(
-              profile: aws_profile,
-              region: aws_region,
-            )
+            @kms = ::Aws::KMS::Client.new()
 
             resp = @kms.encrypt({
               key_id: key_id,
@@ -46,13 +34,7 @@ class Hiera
           end
 
           def self.decrypt ciphertext
-            aws_profile = self.option :aws_profile
-            aws_region = self.option :aws_region
-
-            @kms = ::Aws::KMS::Client.new(
-              profile: aws_profile,
-              region: aws_region,
-            )
+            @kms = ::Aws::KMS::Client.new()
 
             resp = @kms.decrypt({
               ciphertext_blob: ciphertext


### PR DESCRIPTION
Without this change it will try to always parse `[default]` and cause confusion

For example:

`~/.aws/config` with

```
[default]
region = us-east-1
sso_start_url = https://redact.awsapps.com/start
sso_region    = us-east-1
sso_role_name  = Auditor

[profile prod]
sso_account_id = 111111111111

[profile prod-admin]
sso_account_id = 111111111111
sso_role_name  = InfrastructureEngineer
```

This will fail as 

```
✗ aws-vault exec prod-admin -- eyaml encrypt -p --encrypt-method kms --kms-key-id arn:aws:kms:us-east-1:111111111111:alias/puppet-hiera --kms-aws-region=us-east-1 --output string
Enter password: **************************************************************************
[hiera-eyaml-core] Missing required keys: [:sso_account_id]
```

the error? it is trying to parse my aws config and auth for me because it sees `sso_*` in the config

if i move `sso_account_id = 111111111111` to [default] it errors `[hiera-eyaml-core] The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.`

The fix is to remove logic from here which will allow the AWS SDK to use all of its fallback methods (env vars, config file directly, 169.254.169.254, etc)

I tested this locally and it worked as expected

```
✗ aws-vault exec prod-admin -- eyaml encrypt -p --encrypt-method kms --kms-key-id arn:aws:kms:us-east-1:111111111111:alias/puppet-hiera --output string
Enter password: ****

ENC[KMS,AQICAHhaHXZBoyi5e2tMpTnF/e80iXVylMOycUV81ZuOk5OqwgEe6Aa/VAa/7X5J4d8jXt40AAAAYjBgBgkqhkiG9w0BBwagUzBRAgEAMEwGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAfUbQV/br5UUESKnAgEQgB8hc+el4SdWPOpggCQURSr6lonom0Fwh33RWsIYyDdP]
```